### PR TITLE
Add teleport, a virtual KVM for OS X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Projects in Swift language will be marked with a 🔶, feel free to add your pro
 - [Sequel Pro](https://github.com/sequelpro/sequelpro) - MySQL database management for Mac OS X.
 - [gInbox](https://github.com/chenasraf/gInbox) - A Mac wrapper for Inbox by Gmail. 🔶
 - [Hacky for Mac](https://github.com/eliaskg/Hacky) - Hacky for Mac provides browsing Hacker News in a clean and minimalistic way.
+- [teleport](https://github.com/abyssoft/teleport) - teleport lets you use a single mouse and keyboard to control several Macs.
 
 # Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Its landing page is http://www.abyssoft.com/software/teleport/ where you can find a description, screenshots, release download links, etc.

In fact, I was tempted to use a different format:
- [teleport](http://www.abyssoft.com/software/teleport/) ([source](https://github.com/abyssoft/teleport)) - teleport lets you use a single mouse and keyboard to control several Macs.

Because the source code repository README currently is very basic. The landing page is much more complete. But finding the link to source code is not obvious, it is linked in the news section of the website:

![image](https://cloud.githubusercontent.com/assets/1924134/9294992/6baa220c-4413-11e5-822d-3ef729dcde60.png)

But I couldn't do that because it contradicts your contribution rules:
- Use the following format: `[PACKAGE](LINK) - DESCRIPTION.`
