### PR TITLE
Use correct name of operating system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # awesome-osx
-A curated list of awesome Mac OS open source projects and libraries. There is no pre-established order of items, they are in order of submission. If you'd like to contribute please read the [guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md). If you're working on iOS I'd also recommend checking out [vsouza](https://github.com/vsouza)'s [awesome-ios](https://github.com/vsouza/awesome-ios)
+A curated list of awesome OS X open source projects and libraries. There is no pre-established order of items, they are in order of submission. If you'd like to contribute please read the [guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md). If you're working on iOS I'd also recommend checking out [vsouza](https://github.com/vsouza)'s [awesome-ios](https://github.com/vsouza/awesome-ios).
 
 Projects in Swift language will be marked with a 🔶, feel free to add your project.
 
-# Open Source Mac Apps
+# Open Source OS X Apps
 - [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - A Caffeine clone for OS X Yosemite (and Dark Mode).
 - [Messenger for Mac](https://github.com/rsms/fb-mac-messenger) - Mac app wrapping Facebook's Messenger for desktop.
 - [Stockfish](https://github.com/daylen/stockfish-mac) - Beautiful, powerful chess app for the Mac.
@@ -16,7 +16,7 @@ Projects in Swift language will be marked with a 🔶, feel free to add your pro
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Mac Media Keys for the Masses.
 - [Sonora](https://github.com/sonoramac/Sonora) - A minimal, beautifully designed music player for OS X.
 - [Bind](https://github.com/almonk/bind) - A design tool for interfaces.
-- [Sequel Pro](https://github.com/sequelpro/sequelpro) - MySQL database management for Mac OS X.
+- [Sequel Pro](https://github.com/sequelpro/sequelpro) - MySQL database management for OS X.
 - [gInbox](https://github.com/chenasraf/gInbox) - A Mac wrapper for Inbox by Gmail. 🔶
 - [Hacky for Mac](https://github.com/eliaskg/Hacky) - Hacky for Mac provides browsing Hacker News in a clean and minimalistic way.
 


### PR DESCRIPTION
As of version 10.8 Mountain Lion, the name of the operating system was renamed from "Mac OS X" to just "OS X".

Mac\* (MacBook, Mac Pro, etc.) is the name of the computer hardware. OS X is the name of its operating system.

Similarly, i\* (iPhone, iPad, etc.) is the name of the mobile device hardware. iOS is the name of its operating system.

I only changes instances of "Mac OS" and "Mac OS X" to "OS X", since that was referring to software (by an incorrect name). I kept instances of just "Mac" (e.g. "Mac app") because that refers to the hardware (by a correct name), and it's not up to me to change that but up to the app developer.

Sources:
- https://en.wikipedia.org/wiki/OS_X_Mountain_Lion#cite_note-PR-16-02-2
- https://en.wikipedia.org/wiki/OS_X_Mountain_Lion#cite_note-dropsmac-4
