### PR TITLE
Add SnapHotkey — keyboard shortcut app switcher for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [ChitChat](https://github.com/stonesam92/ChitChat) - A native Mac app wrapper for WhatsApp Web.
 - [Color Picker Pro](https://github.com/oscardelben/Color-Picker-Pro) - Color Detection Tool for Designers and Developers.
 - [SketchToolbox](https://github.com/buzzfeed/Sketch-Toolbox) - A plugin manager for Sketch.app.
+- [SnapHotkey](https://snaphotkey.com) - Map keyboard shortcuts directly to Mac apps — one key per app, no Cmd+Tab cycling. ($9.99)
 - [Spectacle](https://github.com/eczarny/spectacle) - Spectacle allows you to organize your windows without using a mouse.
 - [Macdown](https://github.com/uranusjr/macdown) - Open source Markdown editor for OS X.
 - [Radiant Player](https://github.com/kbhomes/radiant-player-mac) - Turn Google Play Music into a separate, beautiful application that integrates with your Mac.


### PR DESCRIPTION
SnapHotkey maps keyboard shortcuts directly to Mac apps — press one key to switch instantly, no Cmd+Tab cycling needed. Supports left/right modifier key distinction, show/hide toggle, and multi-window cycling. macOS only, $9.99 one-time.

Added under **Apps** section alongside other window management tools like Spectacle.