### PR TITLE
Add Agent Island

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ _Note: 🔶 denotes projects written in Swift._
 - [Lantern](https://github.com/BurntCaramel/Lantern) - A dedicated tool for website auditing and crawling. 🔶
 - [Clocker](https://github.com/Abhishaker17/Clocker) - A menubar utility for keeping track of your friends/colleagues in different timezones.
 - [2FHey](https://github.com/SoFriendly/2fhey) - iMessage AutoFill For Any Browser. Auto-copy 2FA & OTP codes into Firefox & Google Chrome
+- [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions with live status and auto-resume for selected long-running tasks. 🔶
 
 ## Contributing
 [See the guide](https://github.com/AndrewSB/awesome-osx/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Adds Agent Island to the Apps section.\n\nAgent Island is an open-source Swift macOS app that lives in the MacBook notch and helps Claude Code/Codex users monitor session state and auto-resume selected long-running tasks.\n\nChecks:\n- Searched existing README for Agent Island.\n- Ran git diff --check.